### PR TITLE
Add license (MIT)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+# The MIT License
+
+Copyright 2021 <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License
 
-Copyright 2021 <COPYRIGHT HOLDER>
+Copyright 2021 Dr. James "Jim" Burke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "microsim"
 version = "0.0.1"
 description = "Open-source chronic disease simulation framework for population health"
 authors = []
-license = ""
+license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
This PR makes explicit that this project is released under the MIT license by:
- adding a `LICENSE.md file`, containing the text of the MIT license (with a copyright date of 2021 and with Dr. Jim Burke as the copyright holder), and
- setting the `tool.poetry.license` field to `"MIT"` in `pyproject.toml` (which is/will be used to build the PyPI package)

We will want this to be able to accept contributions but also to allow people to start using the code if they so desire.

The only place I can think of the license needing to be changed outside of this PR is on the GitHub project page, though I also wouldn't be surprised (but don't know for sure) if GitHub has a scraper to automatically change it. Either way, I will make sure it is changed there as well after merging this PR.