### PR TITLE
Fix person random effects init

### DIFF
--- a/microsim/person.py
+++ b/microsim/person.py
@@ -54,7 +54,7 @@ class Person:
         initializationRepository =None,
         selfReportStrokeAge=None,
         selfReportMIAge=None,
-        randomEffects=dict(),
+        randomEffects=None,
         **kwargs,
     ) -> None:
 
@@ -118,7 +118,7 @@ class Person:
             self._afib = [False]
 
         # for outcome mocels that require random effects, store in this dictionary
-        self._randomEffects = randomEffects
+        self._randomEffects = dict(randomEffects) if randomEffects is not None else {}
 
         # lucianatag: for this and GCP, this approach is a bit inelegant. the idea is to have classees that can be swapped out
         # at the population level to change the behavior about how people change over time.

--- a/microsim/person.py
+++ b/microsim/person.py
@@ -118,7 +118,9 @@ class Person:
             self._afib = [False]
 
         # for outcome mocels that require random effects, store in this dictionary
-        self._randomEffects = dict(randomEffects) if randomEffects is not None else {}
+        self._randomEffects = {'gcp': 0}
+        if randomEffects is not None:
+            self._randomEffects.update(randomEffects)
 
         # lucianatag: for this and GCP, this approach is a bit inelegant. the idea is to have classees that can be swapped out
         # at the population level to change the behavior about how people change over time.

--- a/microsim/test/test_gcp_model.py
+++ b/microsim/test/test_gcp_model.py
@@ -125,3 +125,23 @@ class TestGCPModel(unittest.TestCase):
         self._test_case_one._randomEffects['gcp'] = 5
         self.assertAlmostEqual(
             64.45419405-2.7905+5, GCPModel().get_risk_for_person(person=self._test_case_one, years=1, test=True), places=1)
+
+    def test_gcp_random_effect_independent_per_person(self):
+        expected_case_one_gcp = 66.66369405
+        expected_case_two_gcp = 51.34845213
+        self._test_case_one._randomEffects['gcp'] = 5
+        gcp_model = GCPModel()
+
+        actual_case_one_gcp = gcp_model.get_risk_for_person(self._test_case_one, test=True)
+        actual_case_two_gcp = gcp_model.get_risk_for_person(self._test_case_two, test=True)
+
+        self.assertAlmostEqual(
+            expected_case_one_gcp,
+            actual_case_one_gcp,
+            places=1
+        )
+        self.assertAlmostEqual(
+            expected_case_two_gcp,
+            actual_case_two_gcp,
+            places=1
+        )


### PR DESCRIPTION
This PR fixes that bug that could have prevented the implementation of individual-level random effects from working correctly.  It also adds a test to verify the fix.

Specifically, I noticed that [the `randomEffects` argument in `Person.__init__` had a dictionary as its default value](https://github.com/jburke5/microsim/blob/8a05645dfb180713b43351e9f577347dfd34fd41/microsim/person.py#L57), which [was then directly assigned to the `Person._randomEffects` property](https://github.com/jburke5/microsim/blob/8a05645dfb180713b43351e9f577347dfd34fd41/microsim/person.py#L121). Because default argument values are set when the function is defined rather than when it is called, every `Person` object instantiated without an explicit `randomEffects` argument would have a reference to the same dictionary, and a key added to or mutated on one changed them all. This would not be the intended behavior.

Fortunately, the fix is simple: set the default argument's value to `None` (which is immutable), and instantiate a new dictionary if the argument's value is `None`.

While there is currently no evidence that this bug affected the analyses, it did infiltrate the tests. Twenty tests started failing because of a missing value for the GCP random effect after a fix was implemented. My current explanation is that an early test mutated the random effects dictionary on their test person after instantiation, so all subsequent tests passed because their test `Person` objects had either the now-mutated default argument or a different, explicitly specified dictionary. (Yikes!) Hence, as a workaround, `Person`'s random effect dictionary has a default GCP random effect value of 0.