### PR TITLE
Fixes Following Python 3.9 Upgrade

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@
 The MICROSIM project is built on many other software packages that serve the following roles:
 
 * **Development environment with statistical tools**: We use the [Python programming language](https://www.python.org/) with the [statsmodels module](https://www.statsmodels.org/stable/index.html) to run the statistical modeling and analysis. *This environment is what actually runs the code*, roughly analogous to Stata/SPSS. The term "environment" is used because it contains many tools that work together to make it possible. Below are the main players and their roles:
-  * Python 3.7 - a general purpose programming language that has a large software ecosystem
+  * Python 3.9 - a general purpose programming language that has a large software ecosystem
   * statsmodels - statistical modeling, testing, and data exploration
   * numpy, scipy, pandas - basic packages for numerical analysis, scientific functions, and data frames
   * [Poetry](https://python-poetry.org/) - tool to install Python packages such as those listed above
@@ -38,11 +38,11 @@ Installing all of the above can be daunting, but the steps below should give a s
     exec $SHELL
     ```
 
-1. Install Python 3.7 with pyenv. On macOS and Linux, running the following command will install 3.7.7, the latest release of Python 3.7:
+1. Install Python 3.9 with pyenv. On macOS and Linux, running the following command will install 3.9.13, the latest release of Python 3.9 at time of writing:
 
     ```
-    pyenv install 3.7.7
-    pyenv global 3.7.7
+    pyenv install 3.9.13
+    pyenv global 3.9.13
     ```
 
 1. Install [pipx](https://github.com/pipxproject/pipx), a tool to manage command line Python tools

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the broad framework for representing a representative population and modeling individual cardiovascular risk factors, outcomes and cognition.
 
 ## Development Quickstart
-This section assumes you have Python 3.7+ with `pip` installed. You will also need to [install `poetry`](https://poetry.eustace.io/docs/#installation) to install dependencies, run development commands, and build the package.
+This section assumes you have Python 3.9+ with `pip` installed. You will also need to [install `poetry`](https://poetry.eustace.io/docs/#installation) to install dependencies, run development commands, and build the package.
 
 For a more gentle introduction, try the [installation guide](INSTALL.md).
 

--- a/microsim/bp_treatment_strategies.py
+++ b/microsim/bp_treatment_strategies.py
@@ -88,7 +88,7 @@ class AddBPTreatmentMedsToGoal120(BaseTreatmentStrategy):
 
     def get_treatment_recalibration_for_person(self, person):
         medsForGoal = self.get_meds_needed_for_goal(person.sbp[-1], person.dbp[-1])
-        return {OutcomeType.STROKE: 0.79 ** medsForGoal, OutcomeType.MI: 0.87 ** medsForGoal}
+        return {OutcomeType.STROKE: 0.79**medsForGoal, OutcomeType.MI: 0.87**medsForGoal}
 
     def repeat_treatment_strategy(self):
         return True

--- a/microsim/gcp_model.py
+++ b/microsim/gcp_model.py
@@ -12,9 +12,25 @@ class GCPModel:
 
     # TODO — what do we need to do with the random intercept? shouls we take a draw per person and assign it?
     # if we don't do that there is going to be mroe change in cognitive trajectory per person that we'd expect...
-    def calc_linear_predictor_for_patient_characteristics(self, yearsInSim, raceEthnicity, gender, baseAge,
-        education, alcohol, smokingStatus, bmi, waist, totChol, meanSBP, anyAntiHpertensive, fastingGlucose,
-        physicalActivity, afib, test=False):
+    def calc_linear_predictor_for_patient_characteristics(
+        self,
+        yearsInSim,
+        raceEthnicity,
+        gender,
+        baseAge,
+        education,
+        alcohol,
+        smokingStatus,
+        bmi,
+        waist,
+        totChol,
+        meanSBP,
+        anyAntiHpertensive,
+        fastingGlucose,
+        physicalActivity,
+        afib,
+        test=False,
+    ):
         xb = 55.6090
         xb += yearsInSim * -0.2031
         if raceEthnicity == NHANESRaceEthnicity.NON_HISPANIC_BLACK:
@@ -59,32 +75,48 @@ class GCPModel:
             xb += -1.6579
         return xb
 
-
     def get_risk_for_person(self, person, years=1, vectorized=False, test=False):
         random_effect = 0
         if not vectorized:
             random_effect = person._randomEffects["gcp"] if "gcp" in person._randomEffects else 0
         residual = 0 if test else np.random.normal(0.38, 6.99)
-        
+
         linPred = 0
         if vectorized:
-            linPred = self.calc_linear_predictor_for_patient_characteristics(yearsInSim=person.totalYearsInSim,
-                raceEthnicity=person.raceEthnicity, gender=person.gender, baseAge=person.baseAge,
-                education=person.education, alcohol=person.alcoholPerWeek, 
-                smokingStatus=person.smokingStatus, bmi=person.bmi, waist=person.waist,
-                totChol=person.totChol, meanSBP=person.meanSbp, 
+            linPred = self.calc_linear_predictor_for_patient_characteristics(
+                yearsInSim=person.totalYearsInSim,
+                raceEthnicity=person.raceEthnicity,
+                gender=person.gender,
+                baseAge=person.baseAge,
+                education=person.education,
+                alcohol=person.alcoholPerWeek,
+                smokingStatus=person.smokingStatus,
+                bmi=person.bmi,
+                waist=person.waist,
+                totChol=person.totChol,
+                meanSBP=person.meanSbp,
                 anyAntiHpertensive=(person.antiHypertensiveCount > 0),
-                fastingGlucose=Person.convert_a1c_to_fasting_glucose(person.a1c), physicalActivity=person.anyPhysicalActivity,
-                afib=person.afib)
+                fastingGlucose=Person.convert_a1c_to_fasting_glucose(person.a1c),
+                physicalActivity=person.anyPhysicalActivity,
+                afib=person.afib,
+            )
         else:
-            linPred = self.calc_linear_predictor_for_patient_characteristics(yearsInSim=person.years_in_simulation(),
-                raceEthnicity=person._raceEthnicity, gender=person._gender, baseAge=person._age[0],
-                education=person._education, alcohol=person._alcoholPerWeek[-1], 
-                smokingStatus=person._smokingStatus, bmi=person._bmi[-1], waist=person._waist[-1],
-                totChol=person._totChol[-1], meanSBP=np.array(person._sbp).mean(), 
+            linPred = self.calc_linear_predictor_for_patient_characteristics(
+                yearsInSim=person.years_in_simulation(),
+                raceEthnicity=person._raceEthnicity,
+                gender=person._gender,
+                baseAge=person._age[0],
+                education=person._education,
+                alcohol=person._alcoholPerWeek[-1],
+                smokingStatus=person._smokingStatus,
+                bmi=person._bmi[-1],
+                waist=person._waist[-1],
+                totChol=person._totChol[-1],
+                meanSBP=np.array(person._sbp).mean(),
                 anyAntiHpertensive=(person._antiHypertensiveCount[-1] > 0),
-                fastingGlucose=person.get_fasting_glucose(not test), physicalActivity=person._anyPhysicalActivity[-1],
-                afib=person._afib[-1])
+                fastingGlucose=person.get_fasting_glucose(not test),
+                physicalActivity=person._anyPhysicalActivity[-1],
+                afib=person._afib[-1],
+            )
 
-        
         return linPred + random_effect + residual

--- a/microsim/gfr_equation.py
+++ b/microsim/gfr_equation.py
@@ -69,4 +69,4 @@ class GFREquation:
         ].iloc[0]["constant"]
 
         # print(f"thresholds: {crThreshold} constant: {constant} exponent: {exponent} female: {self._gender==NHANESGender.FEMALE}, black: {self._raceEthnicity==NHANESRaceEthnicity.NON_HISPANIC_BLACK}, cr: {self._creatinine[-1]}")
-        return constant * (x.creatinine / crThreshold) ** exponent * 0.993 ** x.age
+        return constant * (x.creatinine / crThreshold) ** exponent * 0.993**x.age

--- a/microsim/model_argument_transform.py
+++ b/microsim/model_argument_transform.py
@@ -103,7 +103,7 @@ class SquareTransform(AbstractBaseTransform):
     """Returns the square (one or many) of the given value."""
 
     def apply(self, value):
-        return value ** 2
+        return value**2
 
 
 class FirstElementTransform(AbstractBaseTransform):

--- a/microsim/population.py
+++ b/microsim/population.py
@@ -298,7 +298,7 @@ class Population:
             # the change standards are for a single medication
             recalibration_standard_for_med_count = treatment_outcome_standard.copy()
             for key, value in recalibration_standard_for_med_count.items():
-                recalibration_standard_for_med_count[key] = value ** i
+                recalibration_standard_for_med_count[key] = value**i
 
             if len(recalibrationPopForMedCount) > 0:
                 # recalibrate stroke
@@ -790,17 +790,21 @@ class Population:
         if parallel:
             pandarallel.initialize(verbose=1)
             return pd.DataFrame(
-                list(self._people.parallel_apply(
-                    self.get_person_attributes_from_person,
-                    timeVaryingCovariates=self._timeVaryingCovariates,
-                ))
+                list(
+                    self._people.parallel_apply(
+                        self.get_person_attributes_from_person,
+                        timeVaryingCovariates=self._timeVaryingCovariates,
+                    )
+                )
             )
         else:
             return pd.DataFrame(
-                list(self._people.apply(
-                    self.get_person_attributes_from_person,
-                    timeVaryingCovariates=self._timeVaryingCovariates,
-                ))
+                list(
+                    self._people.apply(
+                        self.get_person_attributes_from_person,
+                        timeVaryingCovariates=self._timeVaryingCovariates,
+                    )
+                )
             )
 
     def get_people_current_state_and_summary_as_dataframe(self):

--- a/microsim/statsmodel_cox_model.py
+++ b/microsim/statsmodel_cox_model.py
@@ -22,11 +22,11 @@ class StatsModelCoxModel(StatsModelLinearRiskFactorModel):
     def get_cumulative_hazard_for_interval(self, intervalStart, intervalEnd):
         cumHazardAtIntervalStart = (
             intervalStart * self.one_year_linear_cumulative_hazard
-            + intervalStart ** 2 * self.one_year_quad_cumulative_hazard
+            + intervalStart**2 * self.one_year_quad_cumulative_hazard
         )
         cumHazardAtIntervalEnd = (
             intervalEnd * self.one_year_linear_cumulative_hazard
-            + intervalEnd ** 2 * self.one_year_quad_cumulative_hazard
+            + intervalEnd**2 * self.one_year_quad_cumulative_hazard
         )
         return cumHazardAtIntervalEnd - cumHazardAtIntervalStart
 

--- a/microsim/test/test_dementia_model.py
+++ b/microsim/test/test_dementia_model.py
@@ -181,7 +181,10 @@ class TestDementiaModel(unittest.TestCase):
         self._test_case_three_parametric._gcp.append(self._test_case_two._gcp[0])
 
         self._population_dataframe = init_vectorized_population_dataframe(
-            [self._test_case_one, self._test_case_two,]
+            [
+                self._test_case_one,
+                self._test_case_two,
+            ]
         )
 
     def test_dementia_after_one_year(self):

--- a/microsim/test/test_outcome_repository.py
+++ b/microsim/test/test_outcome_repository.py
@@ -140,7 +140,12 @@ class TestOutcomeRepository(unittest.TestCase):
         )
 
         self._population_dataframe = init_vectorized_population_dataframe(
-            [self._black_female, self._black_male, self._black_treated_male,], with_base_gcp=True,
+            [
+                self._black_female,
+                self._black_male,
+                self._black_treated_male,
+            ],
+            with_base_gcp=True,
         )
         self._outcome_model_repository = OutcomeModelRepository()
 
@@ -174,7 +179,8 @@ class TestOutcomeRepository(unittest.TestCase):
     def test_calculate_actual_ten_year_risk_for_person(self):
         p1_data = self._population_dataframe.iloc[0]  # same data as `self._black_female`
         p1_model = self._outcome_model_repository.select_model_for_person(
-            PersonRowWrapper(p1_data), OutcomeModelType.CARDIOVASCULAR,
+            PersonRowWrapper(p1_data),
+            OutcomeModelType.CARDIOVASCULAR,
         )
         p1_ten_year_risk = p1_model.transform_to_ten_year_risk(
             p1_model.get_one_year_linear_predictor(p1_data, vectorized=True)
@@ -186,7 +192,8 @@ class TestOutcomeRepository(unittest.TestCase):
         # the race interaction term
         p2_data = self._population_dataframe.iloc[1]  # same data as `self._black_male`
         p2_model = self._outcome_model_repository.select_model_for_person(
-            PersonRowWrapper(p2_data), OutcomeModelType.CARDIOVASCULAR,
+            PersonRowWrapper(p2_data),
+            OutcomeModelType.CARDIOVASCULAR,
         )
         p2_ten_year_risk = p2_model.transform_to_ten_year_risk(
             p2_model.get_one_year_linear_predictor(p2_data, vectorized=True)
@@ -196,13 +203,19 @@ class TestOutcomeRepository(unittest.TestCase):
     def test_approximate_one_year_risk_for_person(self):
         p1_data = self._population_dataframe.iloc[0]  # same data as `self._black_female`
         p1_one_year_risk = self._outcome_model_repository.get_risk_for_person(
-            p1_data, OutcomeModelType.CARDIOVASCULAR, years=1, vectorized=True,
+            p1_data,
+            OutcomeModelType.CARDIOVASCULAR,
+            years=1,
+            vectorized=True,
         )
         self.assertAlmostEqual(0.017654 / 10, p1_one_year_risk, delta=0.03)
 
         p2_data = self._population_dataframe.iloc[1]  # same data as `self._black_male`
         p2_one_year_risk = self._outcome_model_repository.get_risk_for_person(
-            p2_data, OutcomeModelType.CARDIOVASCULAR, years=1, vectorized=True,
+            p2_data,
+            OutcomeModelType.CARDIOVASCULAR,
+            years=1,
+            vectorized=True,
         )
         self.assertAlmostEqual(0.03476 / 10, p2_one_year_risk, delta=0.03)
 
@@ -211,7 +224,8 @@ class TestOutcomeRepository(unittest.TestCase):
         p3_data = self._population_dataframe.iloc[2]  # same data as `self._treated_black_male`
 
         model = self._outcome_model_repository.select_model_for_person(
-            PersonRowWrapper(p3_data), OutcomeModelType.CARDIOVASCULAR,
+            PersonRowWrapper(p3_data),
+            OutcomeModelType.CARDIOVASCULAR,
         )
         actual_ten_year_risk = model.transform_to_ten_year_risk(
             model.get_one_year_linear_predictor(self._black_treated_male)
@@ -223,7 +237,10 @@ class TestOutcomeRepository(unittest.TestCase):
         p3_data = self._population_dataframe.iloc[2]  # same data as `self._treated_black_male`
 
         actual_one_year_risk = self._outcome_model_repository.get_risk_for_person(
-            p3_data, OutcomeModelType.CARDIOVASCULAR, years=1, vectorized=True,
+            p3_data,
+            OutcomeModelType.CARDIOVASCULAR,
+            years=1,
+            vectorized=True,
         )
 
         self.assertAlmostEqual(0.069810753 / 10, actual_one_year_risk, delta=0.03)

--- a/microsim/test/test_person_advance_outcomes.py
+++ b/microsim/test/test_person_advance_outcomes.py
@@ -70,7 +70,8 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         self.joe_with_stroke.add_outcome_event(Outcome(OutcomeType.STROKE, False))
 
         self._population_dataframe = init_vectorized_population_dataframe(
-            [self.joe, self.joe_with_mi, self.joe_with_stroke], with_base_gcp=True,
+            [self.joe, self.joe_with_mi, self.joe_with_stroke],
+            with_base_gcp=True,
         )
 
         self._always_positive_repository = AlwaysPositiveOutcomeRepository()
@@ -96,10 +97,14 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         joe_data = self._population_dataframe.iloc[0]
 
         is_max_prob_mi_fatal = self.cvDeterminer._will_have_fatal_mi(
-            joe_data, vectorized=True, overrideMIProb=1.0,
+            joe_data,
+            vectorized=True,
+            overrideMIProb=1.0,
         )
         is_min_prob_mi_fatal = self.cvDeterminer._will_have_fatal_mi(
-            joe_data, vectorized=True, overrideMIProb=0.0,
+            joe_data,
+            vectorized=True,
+            overrideMIProb=0.0,
         )
 
         self.assertTrue(is_max_prob_mi_fatal)
@@ -112,10 +117,14 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         joe_with_mi_data = self._population_dataframe.iloc[1]  # same as joe_data plus 1 MI
 
         will_have_fatal_first_mi = self.cvDeterminer._will_have_fatal_mi(
-            joe_data, vectorized=True, overrideMIProb=0.0,
+            joe_data,
+            vectorized=True,
+            overrideMIProb=0.0,
         )
         will_have_fatal_second_mi = self.cvDeterminer._will_have_fatal_mi(
-            joe_with_mi_data, vectorized=True, overrideMIProb=0.0,
+            joe_with_mi_data,
+            vectorized=True,
+            overrideMIProb=0.0,
         )
 
         self.assertFalse(will_have_fatal_first_mi)
@@ -130,10 +139,14 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         joe_with_stroke_data = self._population_dataframe.iloc[2]  # same as joe_data plus 1 stroke
 
         will_have_fatal_first_stroke = self.cvDeterminer._will_have_fatal_stroke(
-            joe_data, vectorized=True, overrideStrokeProb=0.0,
+            joe_data,
+            vectorized=True,
+            overrideStrokeProb=0.0,
         )
         will_have_fatal_second_stroke = self.cvDeterminer._will_have_fatal_stroke(
-            joe_with_stroke_data, vectorized=True, overrideStrokeProb=0.0,
+            joe_with_stroke_data,
+            vectorized=True,
+            overrideStrokeProb=0.0,
         )
 
         self.assertFalse(will_have_fatal_first_stroke)
@@ -145,10 +158,14 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         joe_data = self._population_dataframe.iloc[0]
 
         is_max_prob_stroke_fatal = self.cvDeterminer._will_have_fatal_stroke(
-            joe_data, vectorized=True, overrideStrokeProb=1.0,
+            joe_data,
+            vectorized=True,
+            overrideStrokeProb=1.0,
         )
         is_min_prob_stroke_fatal = self.cvDeterminer._will_have_fatal_stroke(
-            joe_data, vectorized=True, overrideStrokeProb=0.0,
+            joe_data,
+            vectorized=True,
+            overrideStrokeProb=0.0,
         )
 
         self.assertTrue(is_max_prob_stroke_fatal)
@@ -158,10 +175,16 @@ class TestPersonAdvanceOutcomes(unittest.TestCase):
         joe_data = self._population_dataframe.iloc[0]
 
         has_mi_max_manual_prob = self.cvDeterminer._will_have_mi(
-            joe_data, outcome_model_repository=None, vectorized=False, manualMIProb=1.0,
+            joe_data,
+            outcome_model_repository=None,
+            vectorized=False,
+            manualMIProb=1.0,
         )
         has_mi_min_manual_prob = self.cvDeterminer._will_have_mi(
-            joe_data, outcome_model_repository=None, vectorized=False, manualMIProb=0.0,
+            joe_data,
+            outcome_model_repository=None,
+            vectorized=False,
+            manualMIProb=0.0,
         )
 
         self.assertTrue(has_mi_max_manual_prob)

--- a/microsim/test/test_statsmodel_linear_risk_factor_model.py
+++ b/microsim/test/test_statsmodel_linear_risk_factor_model.py
@@ -90,7 +90,8 @@ class TestStatsModelLinearRiskFactorModel(unittest.TestCase):
         for person in self.people:
             self.advancePerson(person)
         self.population_dataframe = init_vectorized_population_dataframe(
-            self.people, with_base_gcp=True,
+            self.people,
+            with_base_gcp=True,
         )
 
         df2 = pd.DataFrame(

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,28 +16,24 @@ python-versions = "*"
 
 [[package]]
 name = "black"
-version = "21.12b0"
+version = "22.3.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
 python-versions = ">=3.6.2"
 
 [package.dependencies]
-click = ">=7.1.2"
+click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0,<1"
+pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = ">=0.2.6,<2.0.0"
-typing-extensions = [
-    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
-    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
-]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
@@ -412,11 +408,11 @@ docs = ["sphinx", "nbconvert", "jupyter-client", "ipykernel", "matplotlib", "nbf
 
 [[package]]
 name = "tomli"
-version = "1.2.3"
+version = "2.0.1"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "traitlets"
@@ -448,7 +444,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "43c034e068a2b2c136bfc2c43ab6f4f5221d12e2954bf956128771a6f535e41f"
+content-hash = "43a12e90f301cd394cef12d88e8fbcf003c7570cc83c71f239faff341c1352c5"
 
 [metadata.files]
 appnope = [
@@ -460,8 +456,29 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 black = [
-    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
-    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
+    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
+    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
+    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
+    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
+    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
+    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
+    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
+    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
+    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
+    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
+    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
+    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
+    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
+    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
+    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
+    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
+    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
@@ -698,8 +715,8 @@ statsmodels = [
     {file = "statsmodels-0.13.2.tar.gz", hash = "sha256:77dc292c9939c036a476f1770f9d08976b05437daa229928da73231147cde7d4"},
 ]
 tomli = [
-    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
-    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 traitlets = [
     {file = "traitlets-5.2.1.post0-py3-none-any.whl", hash = "sha256:f44b708d33d98b0addb40c29d148a761f44af740603a8fd0e2f8b5b27cf0f087"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pandarallel = "^1.5.1"
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.8"
 ipython = "^7.7.0"
-black = "^21.5b2"
+black = "^22.3.0"
 
 [tool.poetry.scripts]
 test = "scripts.test:main"


### PR DESCRIPTION
This PR contains two fixes related to the recent dependency update and Python 3.9 upgrade:
1. Updates `README.md` and `INSTALL.md` to reflect the new Python major version (3.9), and
2. Updates `black` to a new major version to fix a bug that prevented it from running. (This PR also contains the formatting changes from running the new version of `black` on this repository.)

Details for #&#8203;2: `black` 21.11b was incompatible with a newer version of one of its dependencies (`click` 8.1.3), which was likely installed either when updating dependencies or when upgrading to Python 3.9. A fix was available in `black` 22.3.0, and while a patch fix was technically possible, the major version was updated instead to (finally) move onto stable releases of `black`.