### PR TITLE
fixed bug on line 171 population.py

### DIFF
--- a/microsim/population.py
+++ b/microsim/population.py
@@ -168,7 +168,7 @@ class Population:
                 alive["dementiaNext"] = np.repeat(False, len(alive))
 
             alive.loc[alive["dementiaNext"] == 1, "ageAtFirstDementia"] = alive.age
-            alive["dementia"] = newDementia | alive["dementia"]
+            alive["dementia"] = alive["dementiaNext"] | alive["dementia"]
 
             numberAliveBeforeRecal = len(alive)
 


### PR DESCRIPTION
On line 171 in population.py, variable newDementia was used but there was a possibility that that variable would not be defined prior to line 171, which would kill the simulation. Changed newDementia to alive['dementiaNext'] which is always defined. 