### PR TITLE
get absolute effect size from trials

### DIFF
--- a/microsim/trials/linear_regression_analysis.py
+++ b/microsim/trials/linear_regression_analysis.py
@@ -6,7 +6,8 @@ class LinearRegressionAnalysis(RegressionAnalysis):
         super().__init__(outcomeAssessor, nameStem)
 
     def analyze(self, treatedPop, untreatedPop):
-        reg = smf.ols("outcome ~ treatment", data=self.get_dataframe(treatedPop, untreatedPop)).fit(disp=False, method_kwargs={"warn_convergence": False})
-        return reg.params['treatment'], reg.bse['treatment'], reg.pvalues['treatment']
+        data=self.get_dataframe(treatedPop, untreatedPop)
+        reg = smf.ols("outcome ~ treatment", data).fit(disp=False, method_kwargs={"warn_convergence": False})
+        return reg.params['treatment'], reg.bse['treatment'], reg.pvalues['treatment'], self.get_absolute_effect_size(data)
 
 

--- a/microsim/trials/logistic_regression_analysis.py
+++ b/microsim/trials/logistic_regression_analysis.py
@@ -6,7 +6,8 @@ class LogisticRegressionAnalysis(RegressionAnalysis):
         super().__init__(outcomeAssessor, nameStem)
 
     def analyze(self, treatedPop, untreatedPop):
-        reg = smf.logit("outcome ~ treatment", data=self.get_dataframe(treatedPop, untreatedPop)).fit(disp=False, method_kwargs={"warn_convergence": False})
-        return reg.params['treatment'], reg.bse['treatment'], reg.pvalues['treatment']
+        data=self.get_dataframe(treatedPop,untreatedPop)
+        reg = smf.logit("outcome ~ treatment", data).fit(disp=False, method_kwargs={"warn_convergence": False})
+        return reg.params['treatment'], reg.bse['treatment'], reg.pvalues['treatment'], self.get_absolute_effect_size(data)
 
 

--- a/microsim/trials/outcome_assessor.py
+++ b/microsim/trials/outcome_assessor.py
@@ -1,17 +1,17 @@
 class OutcomeAssessor:
     DEATH = "death"
     
-    def __init__(self, outcomesTypes):
-        self.outcomeTypes = outcomesTypes
+    def __init__(self, outcomeTypes):
+        self.outcomeTypes = outcomeTypes #assumed to be a python list
 
-    def get_outcome(self, person):
+    def get_outcome(self, person): #RegressionAnalysis assumes that this method returns 0 or 1
         for outcomeType in self.outcomeTypes:
             if outcomeType == OutcomeAssessor.DEATH:
                 outcomeDuringSim = person.is_dead()
             else:
                 outcomeDuringSim = person.has_outcome_during_simulation(outcomeType)
             
-            if outcomeDuringSim:
+            if outcomeDuringSim: #implements a logical OR for all outcomeTypes
                 return True
         return False  
 

--- a/microsim/trials/regression_analysis.py
+++ b/microsim/trials/regression_analysis.py
@@ -11,11 +11,24 @@ class RegressionAnalysis:
         untreatedOutcomes = [self.outcomeAssessor.get_outcome(person) for i, person in enumerate(untreatedPopList)]
 
         treatedOutcomes.extend(untreatedOutcomes)
-        analysisDF = pd.DataFrame({'treatment' : np.append(np.ones(len(treatedPopList)), np.zeros(len(untreatedPopList))),
+        analysisDF = pd.DataFrame({'treatment' : np.append(np.ones(len(treatedPopList),dtype=int), np.zeros(len(untreatedPopList),dtype=int)),
                     'outcome' : treatedOutcomes})
         analysisDF.outcome = analysisDF.outcome.astype('int')
         return analysisDF
     
+    def get_absolute_effect_size(self, analysisDF):
+        #column names and flag values in this method are based on get_dataframe method above
+        analysisDFTreatment = analysisDF.loc[analysisDF["treatment"]==1]
+        analysisDFControl = analysisDF.loc[analysisDF["treatment"]==0]
+        
+        #for logistic regression: returns difference of proportions (# of outcomes)/(# of people in group)
+        #for linear regression: returns difference of attribute means
+        #note: I can use mean for both because LogisticRegressionAnalysis uses, exclusively for now I think,
+        #OutcomeAssessor which returns a value of 1 for True and 0 for False and this allows an easy
+        #calculation of proportions
+        absoluteEffectSize =  analysisDFTreatment["outcome"].mean() - analysisDFControl["outcome"].mean()
+        
+        return absoluteEffectSize
 
 
 

--- a/microsim/trials/trial.py
+++ b/microsim/trials/trial.py
@@ -59,14 +59,15 @@ class Trial:
 
     def analyze(self, duration, sampleSize, treatedPopList, untreatedPopList):
         for analysis in self.trialDescription.analyses:
-            reg, se, pvalue = None, None, None
+            reg, se, pvalue, absoluteEffectSize = None, None, None, None
             try:
-                reg, se, pvalue = analysis.analyze(treatedPopList, untreatedPopList)
+                reg, se, pvalue, absoluteEffectSize = analysis.analyze(treatedPopList, untreatedPopList)
             except PerfectSeparationError: # how to track these is not obvious, now now we'll enter "Nones"
                 pass
             self.analyticResults[get_analysis_name(analysis, duration, sampleSize)] = {'reg' : reg, 
                                                                                         'se' : se, 
-                                                                                        'pvalue': pvalue, 
+                                                                                        'pvalue': pvalue,
+                                                                                        'absEffectSize' : absoluteEffectSize,
                                                                                         'duration' : duration, 
                                                                                         'sampleSize' : sampleSize,
                                                                                         'outcome' :  analysis.outcomeAssessor.get_name(),


### PR DESCRIPTION
Implemented a method in RegressionAnalysis that returns the absolute effect size of a trial (risk difference in logistic, attribute mean difference in linear). The method needs to get the dataframe that the get_dataframe produces (implemented in RegressionAnalysis as well). I am using mean() for both logistic and linear regression.

I added dtype=int just to reduce the probability the conditional statement is not evaluated correctly. 

In the code I had to review for this task, I have added a few comments on what assumptions are made in other parts of the code (to decrease probability things break down later and to spend less time in the future when I need to work on this code again).

A thought/question: It seems to me that OutcomeAssessor was designed to return a binary outcome which is a logical fit for logistic regression. AttritbuteOutcomeAssessor seems to me to be designed to process numerical values, a logical fit for linear regression. I am not sure why there is freedom in choosing one or the other in logistic and linear regression. Is the AttributeOutcomeAssessor going to (in the future) return a binary result?