### PR TITLE
implemented a flag to turn pandarallel on/off

### DIFF
--- a/microsim/sim_settings.py
+++ b/microsim/sim_settings.py
@@ -1,0 +1,4 @@
+
+class simSettings:
+
+	pandarallelFlag = False #controls the use of Pandarallel


### PR DESCRIPTION
overall: implemented a flag to turn on/off pandarallel

1) created sim_settings.py and a class simSettings with this flag
2) modified population.py to use this flag and tested that it works 

With this implementation, every population instance can change its usage of apply/parallel_apply at will. We could also move, perhaps, the if-else statements on applyMethod in the simSettings class but we would not be able to control then
how each instance uses apply/parallel_apply.