### PR TITLE
implemented change in attribute assessment method

### DIFF
--- a/microsim/trials/attribute_outcome_assessor.py
+++ b/microsim/trials/attribute_outcome_assessor.py
@@ -4,9 +4,10 @@ import pandas as pd
 from microsim.outcome import OutcomeType
 
 class AttributeOutcomeAssessor:
-    def __init__(self, attributeName, assessmentMethod):
+    def __init__(self, attributeName, assessmentMethod, attributeParameter=None):
         self.attributeName = attributeName
         self.assessmentMethod = assessmentMethod
+        self.attributeParameter = attributeParameter #used in some, not all, assessment methods
     
     def get_outcome(self, person):
         outcome = None
@@ -17,6 +18,10 @@ class AttributeOutcomeAssessor:
             outcome = pd.Series(attr).mean()
         elif self.assessmentMethod == AssessmentMethod.SUM:
             outcome = pd.Series(attr).sum()
+        elif (self.assessmentMethod == AssessmentMethod.CHANGELESSTHAN) & (self.attributeParameter is not None): #must provide attributeParameter
+            outcome = ( ( attr[-1] - attr[0] ) < self.attributeParameter ) #change = final - initial
+        elif (self.assessmentMethod == AssessmentMethod.CHANGEGREATERTHAN) & (self.attributeParameter is not None): #must provide attributeParameter
+            outcome = ( ( attr[-1] - attr[0] ) > self.attributeParameter ) #change = final - initial
         else:
             raise ValueError(f"Invalid assesmment method: {self.assessmentMethod}")
         return outcome
@@ -28,4 +33,6 @@ class AssessmentMethod(Enum):
     LAST = "last"
     MEAN = "mean"
     SUM = "sum"
+    CHANGELESSTHAN = "changeLessThan"
+    CHANGEGREATERTHAN = "changeGreaterThan"
 


### PR DESCRIPTION
Overall: implemented change in attribute assessment methods. 

One method tests for the change in attribute being greater than a parameter, and another method tests for the
change in attribute being less than a parameter. 

Both of these tests could have been implemented by a single method, but this would place a greater burden on the user to negate the outcome when they wanted the comparison operator that was not implemented.