### PR TITLE
added support for parallel trialsets

### DIFF
--- a/microsim/population.py
+++ b/microsim/population.py
@@ -97,7 +97,6 @@ class Population:
         # get dataframe of people...
         df = self.get_people_current_state_and_summary_as_dataframe()
         alive = df.loc[df.dead == False]
-        pandarallel.initialize(verbose=1)
         # might not need this row...depends o n whethe we do an bulk update on people or an wave-abased update
         waveAtStartOfAdvance = self._currentWave
 
@@ -899,6 +898,13 @@ class Population:
         data['deadAtEndOfSim'] = [x._alive[-1]==False for _, x in self._people.items()]
         return pd.DataFrame(data)
 
+    def use_pandarallel(self,flag): #must be able to change these attributes for instances that used pandarallel and will be passed to multiprocessing
+        if flag:
+            self.applyMethod = pd.DataFrame.parallel_apply
+            self.applyMethodSeries = pd.Series.parallel_apply
+        else:
+            self.applyMethod = pd.DataFrame.apply
+            self.applyMethodSeries = pd.Series.apply
 
 def initializeAFib(person):
     model = load_regression_model("BaselineAFibModel")

--- a/microsim/trials/trial.py
+++ b/microsim/trials/trial.py
@@ -5,17 +5,18 @@ import copy
 import pandas as pd
 
 class Trial:
-    def __init__(self, trialDescription, targetPopulation):
+    
+    def __init__(self, trialDescription, targetPopulation, additionalLabels=None): 
         self.trialDescription = trialDescription
-        self.trialPopulation = self.select_trial_population(targetPopulation, 
-            trialDescription.inclusionFilter, trialDescription.exclusionFilter)
+        self.trialPopulation = self.select_trial_population(targetPopulation, trialDescription.inclusionFilter, trialDescription.exclusionFilter)
         # select our patients from the population
         self.maxSampleSize = pd.Series(trialDescription.sampleSizes).max()
         self.treatedPop, self.untreatedPop = self.randomize(trialDescription.randomizationSchema)
         self.analyticResults = {}
+        self.additionalLabels = additionalLabels 
 
     def select_trial_population(self, targetPopulation, inclusionFilter, exclusionFilter):
-        filteredPeople = list(filter(inclusionFilter, list(targetPopulation._people)))
+        filteredPeople = list(filter(inclusionFilter, list(targetPopulation._people))) 
         return PersonListPopulation(filteredPeople)
 
     def randomize(self, randomizationSchema):
@@ -24,7 +25,7 @@ class Trial:
         randomizedCount = 0
         # might be able to make this more efficient by sampling from the filtered people...
         for i, person in self.trialPopulation._people.items():
-            while randomizedCount < self.maxSampleSize: 
+            while randomizedCount < self.maxSampleSize:
                 if not person.is_dead():
                     if randomizationSchema(person):
                         treatedList.append(copy.deepcopy(person))
@@ -32,18 +33,20 @@ class Trial:
                         untreatedList.append(copy.deepcopy(person))
                     randomizedCount+=1
                 else:
-                    continue 
+                    continue
         return PersonListPopulation(treatedList), PersonListPopulation(untreatedList)
-    
+
     def run(self):
         self.treatedPop._bpTreatmentStrategy = self.trialDescription.treatment
         lastDuration = 0
         for duration in self.trialDescription.durations:
             self.treatedDF, self.treatedAlive = self.treatedPop.advance_vectorized(duration-lastDuration)
             self.untreatedDF, self.untreatedAlive = self.untreatedPop.advance_vectorized(duration-lastDuration)
-            self.analyze(duration, self.maxSampleSize, self.treatedPop._people.tolist(), self.untreatedPop._people.tolist())
+            self.analyze(duration, 
+                         self.maxSampleSize, 
+                         self.treatedPop._people.tolist(), 
+                         self.untreatedPop._people.tolist())
             self.analyzeSmallerTrials(duration)
-            
             lastDuration = duration
 
     def analyzeSmallerTrials(self, duration):
@@ -56,7 +59,6 @@ class Trial:
                 sampleUntreated = self.untreatedPop._people.sample(int(sampleSize/2))
                 self.analyze(duration, sampleSize, sampleTreated.tolist(), sampleUntreated.tolist())
 
-
     def analyze(self, duration, sampleSize, treatedPopList, untreatedPopList):
         for analysis in self.trialDescription.analyses:
             reg, se, pvalue, absoluteEffectSize = None, None, None, None
@@ -64,16 +66,14 @@ class Trial:
                 reg, se, pvalue, absoluteEffectSize = analysis.analyze(treatedPopList, untreatedPopList)
             except PerfectSeparationError: # how to track these is not obvious, now now we'll enter "Nones"
                 pass
-            self.analyticResults[get_analysis_name(analysis, duration, sampleSize)] = {'reg' : reg, 
-                                                                                        'se' : se, 
-                                                                                        'pvalue': pvalue,
-                                                                                        'absEffectSize' : absoluteEffectSize,
-                                                                                        'duration' : duration, 
-                                                                                        'sampleSize' : sampleSize,
-                                                                                        'outcome' :  analysis.outcomeAssessor.get_name(),
-                                                                                        'analysis' : analysis.name}
+            self.analyticResults[get_analysis_name(analysis, duration, sampleSize)] = {  'reg' : reg,
+                                                                                         'se' : se,
+                                                                                         'pvalue': pvalue,
+                                                                                         'absEffectSize' : absoluteEffectSize,
+                                                                                         'duration' : duration,
+                                                                                         'sampleSize' : sampleSize,
+                                                                                         'outcome' :  analysis.outcomeAssessor.get_name(),
+                                                                                         'analysis' : analysis.name}
         return self.analyticResults
-        
-        
 
-    
+

--- a/microsim/trials/trial_description.py
+++ b/microsim/trials/trial_description.py
@@ -2,7 +2,7 @@ import numpy as np
 
 class TrialDescription:
     def __init__(self, sampleSizes, durations, inclusionFilter, exclusionFilter, analyses, treatment,
-                randomizationSchema=lambda x : np.random.uniform() < 0.5):
+                randomizationSchema):
 
         self.sampleSizes = sampleSizes
         self.durations = durations

--- a/microsim/trials/trial_utils.py
+++ b/microsim/trials/trial_utils.py
@@ -1,2 +1,9 @@
+import numpy as np
+
 def get_analysis_name(analysis, duration, sampleSize):
     return f"{analysis.name}-{str(duration)}Years-{sampleSize}"
+
+#this function can be generalized, for more distributions
+def randomizationSchema(x):
+    return (np.random.uniform() < 0.5) #assumes a uniform distribution
+

--- a/microsim/trials/trialset.py
+++ b/microsim/trials/trialset.py
@@ -1,42 +1,81 @@
 from microsim.trials.trial import Trial
 from microsim.trials.trial_utils import get_analysis_name
+from microsim.outcome_model_type import OutcomeModelType
+from microsim.sim_settings import simSettings
 import pandas as pd
+import multiprocessing as mp
 
 class Trialset:
+    
+    def __init__(self, 
+                 trialDescription, pop, trialCount, 
+                 additionalLabels=None): #additional labels are additional columns on the trialset results dataframe, eg risks used in inclusionFilter
+        self.trialDescription = trialDescription
+        self.pop = pop
+        self.trialCount = trialCount 
+        self.additionalLabels = additionalLabels  
+    
+    def prepareArgsForRun(self): #prepare all arguments needed to run the entire trial set 
+        argsForRun = []	 #arguments will be stored in a list of tuples (multiprocessing map functions accept only tuples to be sent to processes)
+        for iTrial in range(0,self.trialCount):  #for as many trials as the set asks for
+                argsForRun.append((iTrial)) #trialset instances contain all information needed by their trials, so just pass a trial index
+        return argsForRun
+    
+    #having the population as an argument passed to each trial is the reason why python makes copies of the population
+    #when it sends information to the cores running the processes with multiprocessing
+    #currently, this adds a RAM cost = (number of processes) * (population size in RAM)
+    #which suggests a solution: do not pass the actual population to the function the processes run but
+    #some kind of index/link/list/function as an interface to the population
+    #also, to maximize efficiency with TrialsetParallel, a single core must prepare, run and analyze a trial
+    def prepareRunAnalyzeTrial(self, iTrial):
+        print(f'starting trial {iTrial} now', flush=True) #helps to see when trials start
+        trial = Trial(self.trialDescription, 
+                      self.pop, 
+                      additionalLabels=self.additionalLabels) #initialize trial
+        trial.run() #run trial
+        resultsForTrial = [] #and now analyze the trial
+        for analysis in trial.trialDescription.analyses:
+            for duration in trial.trialDescription.durations:
+                for sampleSize in trial.trialDescription.sampleSizes:
+                    resultsForTrial.append(trial.analyticResults[get_analysis_name(analysis, duration, sampleSize)])
+        dfForTrial = pd.DataFrame(resultsForTrial)
+        if trial.additionalLabels is not None:
+            for label, labelVal in trial.additionalLabels.items():
+                dfForTrial[label] = labelVal
+        del trial #trial instance is no longer needed, so release the memory (but python keeps track of references to objects anyway)
+        print(f'ending trial {iTrial} now', flush=True) #helps to see when trials end
+        return dfForTrial #return only results
+    
+class TrialsetParallel(Trialset): #Parallel refers to how trials are run, at any moment there are self.processesCount trials running in parallel
+
+    #TrialsetParallel needs an extra argument than TrialsetSerial, the number of processes to be launched
+    def __init__(self, trialDescription, pop, trialCount, processesCount, additionalLabels=None):
+        self.processesCount = processesCount
+        super().__init__(trialDescription, pop, trialCount, additionalLabels=additionalLabels)
+
+    def run(self): 
+        if simSettings.pandarallelFlag: #multiprocessing processes must not launch pandarallel
+            raise Exception("pandarallelFlag must be set to False prior to running a TrialsetParallel instance")     
+        else:
+            with mp.Pool(self.processesCount) as myPool: #context manager will terminate this pool of processes
+                 #run trials and get back the list of dataframes with the results (trial instance is not returned to save memory)
+                 resultsTrialsetList = myPool.map(self.prepareRunAnalyzeTrial, self.prepareArgsForRun())
+                 resultsTrialsetPd = pd.concat(resultsTrialsetList).reset_index(drop=True) #convert list of dataframes to a single dataframe
+            return resultsTrialsetPd
+
+class TrialsetSerial(Trialset): #Serial refers to how trials are run, at any moment there is only one trial running (which may or may not use pandarallel)
 
     def __init__(self, trialDescription, pop, trialCount, additionalLabels=None):
-        self.trials = []
-        self.trialDescription = trialDescription
-        for i in range(0, trialCount):
-            self.trials.append(Trial(trialDescription, pop))
-        self.additionalLabels = additionalLabels
+        super().__init__(trialDescription, pop, trialCount, additionalLabels=additionalLabels)
 
     def run(self):
-        trialCount = 0
-        for trial in self.trials:
-            if trialCount % 10 == 0:
-                print(f"#################\n#################    Trial Count: {trialCount}")
-            trial.run()
-            trialCount+=1
-        self.resultsDict = self.build_all_results_df()
+        print(f'pandarallelFlag is set to {simSettings.pandarallelFlag}')
+        resultsTrialsetList = []
+        argsForRun = self.prepareArgsForRun()
+        for iTrial in range(self.trialCount):
+                resultsTrialsetList.append(self.prepareRunAnalyzeTrial(argsForRun[iTrial])) #prepare,run,analyze trial and append trial results to list
+                if (iTrial+1) % 10 == 0:
+                        print(f"#################\n#################    Trial Completed: {iTrial}")
+        resultsTrialsetPd = pd.concat(resultsTrialsetList).reset_index(drop=True) #convert list of dataframes to a single dataframe
+        return resultsTrialsetPd
 
-    def get_all_results_dict(self):
-        return self.resultsDict
-    
-    def get_results_for_analysis(self, analysis):
-        return self.resultsDict[analysis]
-
-    def build_all_results_df(self):
-        results = {}
-        for analysis in self.trialDescription.analyses:
-            for duration in self.trialDescription.durations:
-                for sampleSize in self.trialDescription.sampleSizes:
-                    resultsForAnalysis = []
-                    for trial in self.trials:
-                        resultsForAnalysis.append(trial.analyticResults[get_analysis_name(analysis, duration, sampleSize)])
-                    dfForAnalysis = pd.DataFrame(resultsForAnalysis)
-                    if self.additionalLabels is not None:
-                        for label, labelVal in self.additionalLabels.items():
-                            dfForAnalysis[label] = labelVal
-                    results[get_analysis_name(analysis, duration, sampleSize)] = dfForAnalysis
-        return results


### PR DESCRIPTION
Trialset was modified to support both a serial and an efficient parallel trialset run method.

Added a TrialsetSerial subclass that runs trials in a serial manner.

Added a TrialsetParallel subclass that runs trials in a parallel fashion.

The two subclasses return results in an identical format, but the TrialsetParallel subclass requires an extra argument for input (number of processes to be launched).

Possibility: TrialsetSerial and TrialsetParallel run methods could be moved to Trialset which could take an extra
optional argument (number of processes), which could be used for Trialset to decide whether to use the serial or the parallel run method.

Possibility: some work that the user needs to do know on the control of pandarallel can be included in the Trialset subclasses.

The prior approach of running a trialset in a serial fashion with the use of pandarallel is also possible with this implementation. 

Added a population method in order to allow a population to use pandarallel before multiprocessing kicks in.

