### PR TITLE
stopped overwriting smaller sample trial results

### DIFF
--- a/microsim/trials/trial.py
+++ b/microsim/trials/trial.py
@@ -45,7 +45,8 @@ class Trial:
             self.analyze(duration, 
                          self.maxSampleSize, 
                          self.treatedPop._people.tolist(), 
-                         self.untreatedPop._people.tolist())
+                         self.untreatedPop._people.tolist(),
+                         sampleSizeIndex=0) #there is only one maxSampleSize
             self.analyzeSmallerTrials(duration)
             lastDuration = duration
 
@@ -57,16 +58,16 @@ class Trial:
                     continue
                 sampleTreated = self.treatedPop._people.sample(int(sampleSize/2))
                 sampleUntreated = self.untreatedPop._people.sample(int(sampleSize/2))
-                self.analyze(duration, sampleSize, sampleTreated.tolist(), sampleUntreated.tolist())
+                self.analyze(duration, sampleSize, sampleTreated.tolist(), sampleUntreated.tolist(), sampleSizeIndex=i)
 
-    def analyze(self, duration, sampleSize, treatedPopList, untreatedPopList):
+    def analyze(self, duration, sampleSize, treatedPopList, untreatedPopList, sampleSizeIndex=0):
         for analysis in self.trialDescription.analyses:
             reg, se, pvalue, absoluteEffectSize = None, None, None, None
             try:
                 reg, se, pvalue, absoluteEffectSize = analysis.analyze(treatedPopList, untreatedPopList)
             except PerfectSeparationError: # how to track these is not obvious, now now we'll enter "Nones"
                 pass
-            self.analyticResults[get_analysis_name(analysis, duration, sampleSize)] = {  'reg' : reg,
+            self.analyticResults[get_analysis_name(analysis, duration, sampleSize, sampleSizeIndex=sampleSizeIndex)] = {  'reg' : reg,
                                                                                          'se' : se,
                                                                                          'pvalue': pvalue,
                                                                                          'absEffectSize' : absoluteEffectSize,

--- a/microsim/trials/trial_utils.py
+++ b/microsim/trials/trial_utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-def get_analysis_name(analysis, duration, sampleSize):
-    return f"{analysis.name}-{str(duration)}Years-{sampleSize}"
+#sampleSizeIndex is needed due to the trial method analyzeSmallerTrials, without it trial.analyticResults would overwrite smaller sample results
+def get_analysis_name(analysis, duration, sampleSize, sampleSizeIndex=0):
+    return f"{analysis.name}-{str(duration)}Years-{sampleSize}-{sampleSizeIndex}"
 
 #this function can be generalized, for more distributions
 def randomizationSchema(x):

--- a/microsim/trials/trialset.py
+++ b/microsim/trials/trialset.py
@@ -32,12 +32,8 @@ class Trialset:
         trial = Trial(self.trialDescription, 
                       self.pop, 
                       additionalLabels=self.additionalLabels) #initialize trial
-        trial.run() #run trial
-        resultsForTrial = [] #and now analyze the trial
-        for analysis in trial.trialDescription.analyses:
-            for duration in trial.trialDescription.durations:
-                for sampleSize in trial.trialDescription.sampleSizes:
-                    resultsForTrial.append(trial.analyticResults[get_analysis_name(analysis, duration, sampleSize)])
+        trial.run() #run and analyze trial
+        resultsForTrial = list(trial.analyticResults.values())
         dfForTrial = pd.DataFrame(resultsForTrial)
         if trial.additionalLabels is not None:
             for label, labelVal in trial.additionalLabels.items():


### PR DESCRIPTION
The method analyzeSmallerTrials was overwriting the analysis results for the smaller trials because there were multiple dictionary keys with exactly the same sample size and there was no way to distinguish between them. I added a sampleSizeIndex to help distinguish the analysis results of smaller sample sizes. This sampleSizeIndex is not reported on the results dataframe, is only used in the key. The analysis of the max sample size was reported without problems because there was only one.