### PR TITLE
stopped warnings from regression optimizer

### DIFF
--- a/microsim/test/test_treatment_recalibration.py
+++ b/microsim/test/test_treatment_recalibration.py
@@ -264,7 +264,7 @@ class TestTreatmentRecalibration(unittest.TestCase):
         numberOfFatalMIsInBasePopulation = pd.Series(
             [
                 person.has_mi_during_simulation() & person.is_dead()
-                for i, person in neverMIPop._people.iteritems()
+                for i, person in neverMIPop._people.items()
             ]
         ).sum()
         self.assertEqual(self.popSize, numberOfFatalMIsInBasePopulation)
@@ -281,7 +281,7 @@ class TestTreatmentRecalibration(unittest.TestCase):
         numberOfFatalMIsAfterRecalibration = pd.Series(
             [
                 person.has_mi_during_simulation() & person.is_dead()
-                for i, person in neverMIPop._people.iteritems()
+                for i, person in neverMIPop._people.items()
             ]
         ).sum()
 

--- a/microsim/trials/linear_regression_analysis.py
+++ b/microsim/trials/linear_regression_analysis.py
@@ -7,7 +7,7 @@ class LinearRegressionAnalysis(RegressionAnalysis):
 
     def analyze(self, treatedPop, untreatedPop):
         data=self.get_dataframe(treatedPop, untreatedPop)
-        reg = smf.ols("outcome ~ treatment", data).fit(disp=False, method_kwargs={"warn_convergence": False})
+        reg = smf.ols("outcome ~ treatment", data).fit(disp=False)
         return reg.params['treatment'], reg.params['Intercept'], reg.bse['treatment'], reg.pvalues['treatment'], self.get_means(data)
 
 

--- a/microsim/trials/logistic_regression_analysis.py
+++ b/microsim/trials/logistic_regression_analysis.py
@@ -7,7 +7,7 @@ class LogisticRegressionAnalysis(RegressionAnalysis):
 
     def analyze(self, treatedPop, untreatedPop):
         data=self.get_dataframe(treatedPop,untreatedPop)
-        reg = smf.logit("outcome ~ treatment", data).fit(disp=False, method_kwargs={"warn_convergence": False})
+        reg = smf.logit("outcome ~ treatment", data).fit(disp=False)
         return reg.params['treatment'], reg.params['Intercept'], reg.bse['treatment'], reg.pvalues['treatment'], self.get_means(data)
 
 


### PR DESCRIPTION
Removed an argument from trial logistic and linear regressions that was supposed to suppress warnings but ended up creating new warnings....also changed 2 iteritems to items....