### PR TITLE
Model estimated RR bug in recalibration (fixes #40)

### DIFF
--- a/microsim/bp_treatment_strategies.py
+++ b/microsim/bp_treatment_strategies.py
@@ -47,11 +47,18 @@ class AddASingleBPMedTreatmentStrategy(BaseTreatmentStrategy):
         x.dbpNext = x.dbpNext - AddASingleBPMedTreatmentStrategy.dbpLowering
         return x
 
-    def rollback_changes_vectorized(self, x):
-        x.sbpNext = x.sbpNext + AddASingleBPMedTreatmentStrategy.sbpLowering
-        x.dbpNext = x.dbpNext + AddASingleBPMedTreatmentStrategy.dbpLowering
-        x.bpMedsAddedNext = 0
-        x.totalBPMedsAddedNext = 0
+    def rollback_changes_on_current_values_vectorized(self, x):
+        x.sbp = x.sbp + AddASingleBPMedTreatmentStrategy.sbpLowering
+        x.dbp = x.dbp + AddASingleBPMedTreatmentStrategy.dbpLowering
+        x.bpMedsAdded = 0
+        x.totalBPMedsAdded = 0
+        return x
+
+    def get_changes_on_current_values_vectorized(self, x):
+        x.bpMedsAdded = 1
+        x.totalBPMedsAdded = 1
+        x.sbp = x.sbp - AddASingleBPMedTreatmentStrategy.sbpLowering
+        x.dbp = x.dbp - AddASingleBPMedTreatmentStrategy.dbpLowering
         return x
 
 

--- a/microsim/bp_treatment_strategies.py
+++ b/microsim/bp_treatment_strategies.py
@@ -47,19 +47,19 @@ class AddASingleBPMedTreatmentStrategy(BaseTreatmentStrategy):
         x.dbpNext = x.dbpNext - AddASingleBPMedTreatmentStrategy.dbpLowering
         return x
 
-    def rollback_changes_on_current_values_vectorized(self, x):
-        x.sbp = x.sbp + AddASingleBPMedTreatmentStrategy.sbpLowering
-        x.dbp = x.dbp + AddASingleBPMedTreatmentStrategy.dbpLowering
-        x.bpMedsAdded = 0
-        x.totalBPMedsAdded = 0
-        return x
+#    def rollback_changes_on_current_values_vectorized(self, x):
+#        x.sbp = x.sbp + AddASingleBPMedTreatmentStrategy.sbpLowering
+#        x.dbp = x.dbp + AddASingleBPMedTreatmentStrategy.dbpLowering
+#        x.bpMedsAdded = 0
+#        x.totalBPMedsAdded = 0
+#        return x
 
-    def get_changes_on_current_values_vectorized(self, x):
-        x.bpMedsAdded = 1
-        x.totalBPMedsAdded = 1
-        x.sbp = x.sbp - AddASingleBPMedTreatmentStrategy.sbpLowering
-        x.dbp = x.dbp - AddASingleBPMedTreatmentStrategy.dbpLowering
-        return x
+#    def get_changes_on_current_values_vectorized(self, x):
+#        x.bpMedsAdded = 1
+#        x.totalBPMedsAdded = 1
+#        x.sbp = x.sbp - AddASingleBPMedTreatmentStrategy.sbpLowering
+#        x.dbp = x.dbp - AddASingleBPMedTreatmentStrategy.dbpLowering
+#        return x
 
 
 class AddBPTreatmentMedsToGoal120(BaseTreatmentStrategy):

--- a/microsim/bp_treatment_strategies.py
+++ b/microsim/bp_treatment_strategies.py
@@ -47,21 +47,6 @@ class AddASingleBPMedTreatmentStrategy(BaseTreatmentStrategy):
         x.dbpNext = x.dbpNext - AddASingleBPMedTreatmentStrategy.dbpLowering
         return x
 
-#    def rollback_changes_on_current_values_vectorized(self, x):
-#        x.sbp = x.sbp + AddASingleBPMedTreatmentStrategy.sbpLowering
-#        x.dbp = x.dbp + AddASingleBPMedTreatmentStrategy.dbpLowering
-#        x.bpMedsAdded = 0
-#        x.totalBPMedsAdded = 0
-#        return x
-
-#    def get_changes_on_current_values_vectorized(self, x):
-#        x.bpMedsAdded = 1
-#        x.totalBPMedsAdded = 1
-#        x.sbp = x.sbp - AddASingleBPMedTreatmentStrategy.sbpLowering
-#        x.dbp = x.dbp - AddASingleBPMedTreatmentStrategy.dbpLowering
-#        return x
-
-
 class AddBPTreatmentMedsToGoal120(BaseTreatmentStrategy):
     sbpLowering = 5.5
     dbpLowering = 3.1
@@ -120,14 +105,6 @@ class AddBPTreatmentMedsToGoal120(BaseTreatmentStrategy):
         x.dbpNext = x.dbpNext - medsNeeded * AddBPTreatmentMedsToGoal120.dbpLowering
         return x
 
-    def rollback_changes_vectorized(self, x):
-        x.sbpNext = x.sbpNext + x.bpMedsAddedNext * AddBPTreatmentMedsToGoal120.sbpLowering
-        x.dbpNext = x.dbpNext + x.bpMedsAddedNext * AddBPTreatmentMedsToGoal120.dbpLowering
-        # rollback to the prior number of BP meds added
-        x.bpMedsAddedNext = 0
-        x.totalBPMedsAddedNext = x.totalBPMedsAdded
-        return x
-
 class NoBPTreatment(BaseTreatmentStrategy):
     def __init__(self):
         pass
@@ -151,11 +128,6 @@ class NoBPTreatment(BaseTreatmentStrategy):
 
     # BP meds can change via the usual care risk model...but, we won't add any meds...
     def get_changes_vectorized(self, x):
-        x.bpMedsAddedNext = 0
-        x.totalBPMedsAddedNext = 0
-        return x
-
-    def rollback_changes_vectorized(self, x):
         x.bpMedsAddedNext = 0
         x.totalBPMedsAddedNext = 0
         return x

--- a/microsim/population.py
+++ b/microsim/population.py
@@ -108,11 +108,6 @@ class Population:
                 break
             self._currentWave += 1
 
-            #if they survived until now, they are 1 year older, because if we wanted to keep age the same as the one we get initially, 
-            #then we should have started with predicting outcomes using the initial risk factors  
-            #so, I think we are now assuming that everyone survived to increase their age by at least 1 year
-            alive.loc[~alive.dead, "age"] = alive.age + 1 
-
             ########################## RISK FACTORS 
 
             riskFactorsDict = {}
@@ -181,6 +176,8 @@ class Population:
             alive = self.estimate_risks(alive, "treated")
 
             ########################## CLINICAL OUTCOMES
+
+            #the order of the outcomes potentially becomes important if outcomes depend on each other (eg when gcp outcome depends on stroke outcome)
 
             # add these variables here to speed up performance...better than adding one at a time
             # in the advance method...
@@ -259,6 +256,9 @@ class Population:
 
             ########################## UPDATES
             
+            #if they survived until now, they are now 1 year older
+            alive.loc[~alive.dead, "age"] = alive.age + 1
+
             self._totalWavesAdvanced += 1
 
             alive["totalYearsInSim"] = alive["totalYearsInSim"] + 1

--- a/microsim/population.py
+++ b/microsim/population.py
@@ -488,6 +488,7 @@ class Population:
 
         # if negative, the model estimated too few events, if positive, too mnany
         #logging.info(f"bp recalibration, delta: {delta}, number of statuses to change: {numberOfEventStatusesToChange}")
+        logging.info(f"bp recalibration, delta: {delta}, {modelEstimatedRR} - {treatment_outcome_standard[outcomeType]}, {recalibration_pop[treatedRiskVar].mean()}, {recalibration_pop[untreatedRiskVar].mean()}, number of statuses to change: {numberOfEventStatusesToChange}")
 
         if delta < 0:
             if numberOfEventStatusesToChange > 0:

--- a/microsim/population.py
+++ b/microsim/population.py
@@ -404,28 +404,12 @@ class Population:
     # so, i thikn it should be based on the model-predicted risks...
 
     def recalibrate_bp_treatment(self, recalibration_df):
-        logging.info(f"*** before recalibration, mi count: {recalibration_df.miNext.sum()}, stroke count: {recalibration_df.strokeNext.sum()}")
+        #logging.info(f"*** before recalibration, mi count: {recalibration_df.miNext.sum()}, stroke count: {recalibration_df.strokeNext.sum()}")
         treatment_outcome_standard = (
             self._bpTreatmentStrategy.get_treatment_recalibration_for_population()
         )
-        # estimate risk for the people alive at the start of the wave
-        #recalibration_df= self.estimate_risks(recalibration_df, "treated")
 
-        # rollback the treatment effect.
-        # redtag: would like to apply to this to a deeply cloned population, but i can't get that to work
-        # so, for now, applying it to the actual population and then rolling the effect back later.
-        #recalibration_df = recalibration_df.apply(
-        #    self._bpTreatmentStrategy.rollback_changes_on_current_values_vectorized, axis="columns"
-        #)
-
-        # estimate risk after applying the treamtent effect
-        #recalibration_df = self.estimate_risks(recalibration_df, "untreated")
-
-        # hacktag related to above — roll back the treatment effect...
-        #recalibration_df = recalibration_df.apply(
-        #    self._bpTreatmentStrategy.get_changes_on_current_values_vectorized, axis="columns"
-        #)
-        logging.info(f"######## BP meds After redo: {recalibration_df.totalBPMedsAddedNext.value_counts()}")
+        #logging.info(f"######## BP meds After redo: {recalibration_df.totalBPMedsAddedNext.value_counts()}")
         totalBPMedsAddedCapped = recalibration_df['totalBPMedsAddedNext']
         totalBPMedsAddedCapped.loc[totalBPMedsAddedCapped >= BaseTreatmentStrategy.MAX_BP_MEDS] = BaseTreatmentStrategy.MAX_BP_MEDS
         #recalibration_df.loc[recalibration_df['totalBPMedsAddedNext'] >= BaseTreatmentStrategy.MAX_BP_MEDS, 'totalBPMedsAddedCapped'] = BaseTreatmentStrategy.MAX_BP_MEDS
@@ -438,11 +422,11 @@ class Population:
         # it is the lesser of the total number of BP meds actually added (totalBpMedsAdded) or the max cap
         # so, if a treamtent strategy adds 10 medications, they'll effect the BP...but, they 
         # wont' have an additional efect on event reduction over the medication cap
-        logging.info(f"######## BP meds After redo: {recalibration_df.totalBPMedsAddedNext.value_counts()}")
+        #logging.info(f"######## BP meds After redo: {recalibration_df.totalBPMedsAddedNext.value_counts()}")
 
         # recalibrate within each group of added medicaitons so that we can stratify the treamtnet effects
         for i in range(1, BaseTreatmentStrategy.MAX_BP_MEDS + 1):
-            logging.info(f"Roll back for med count: {i}")
+            #logging.info(f"Roll back for med count: {i}")
             recalibrationPopForMedCount = recalibration_df.loc[recalibration_df.totalBPMedsAddedCapped == i]
             # the change standards are for a single medication
             recalibration_standard_for_med_count = treatment_outcome_standard.copy()
@@ -503,7 +487,7 @@ class Population:
                     recalibratedForMedCount.index, "rolledBackEventType"
                 ] = recalibratedForMedCount["rolledBackEventType"]
 
-        logging.info(f"*** after recalibration, mi count: {recalibration_df.miNext.sum()}, stroke count: {recalibration_df.strokeNext.sum()}")
+        #logging.info(f"*** after recalibration, mi count: {recalibration_df.miNext.sum()}, stroke count: {recalibration_df.strokeNext.sum()}")
         recalibration_df.drop(columns=['treatedcombinedRisks', 'treatedstrokeProbabilities', 'treatedstrokeRisks', 'treatedmiRisks', 
                     'untreatedcombinedRisks', 'untreatedstrokeProbabilities', 'untreatedstrokeRisks', 'untreatedmiRisks', 'totalBPMedsAddedCapped', 'rolledBackEventType'], inplace=True)
         return recalibration_df
@@ -540,7 +524,7 @@ class Population:
         fatalityDetermination,
         recalibration_pop,
     ):
-        logging.info(f"create or rollback {outcomeType}, standard: {treatment_outcome_standard[outcomeType]}")
+        #logging.info(f"create or rollback {outcomeType}, standard: {treatment_outcome_standard[outcomeType]}")
 
         modelEstimatedRR = (
             recalibration_pop[treatedRiskVar].mean() / recalibration_pop[untreatedRiskVar].mean()
@@ -567,8 +551,8 @@ class Population:
 
         # if negative, the model estimated too few events, if positive, too mnany
         #logging.info(f"bp recalibration, delta: {delta}, number of statuses to change: {numberOfEventStatusesToChange}")
-        logging.info(f"bp recalibration, delta: {delta} = {modelEstimatedRR} - {treatment_outcome_standard[outcomeType]}")
-        logging.info(f"bp recalibration, treated mean: {recalibration_pop[treatedRiskVar].mean()}, untreated mean: {recalibration_pop[untreatedRiskVar].mean()}")
+        #logging.info(f"bp recalibration, delta: {delta} = {modelEstimatedRR} - {treatment_outcome_standard[outcomeType]}")
+        #logging.info(f"bp recalibration, treated mean: {recalibration_pop[treatedRiskVar].mean()}, untreated mean: {recalibration_pop[untreatedRiskVar].mean()}")
 
         if delta < 0:
             if numberOfEventStatusesToChange > 0:

--- a/microsim/population.py
+++ b/microsim/population.py
@@ -432,7 +432,7 @@ class Population:
         )
 
         #logging.info(f"######## BP meds After redo: {recalibration_df.totalBPMedsAddedNext.value_counts()}")
-        totalBPMedsAddedCapped = recalibration_df['totalBPMedsAddedNext']
+        totalBPMedsAddedCapped = recalibration_df['totalBPMedsAddedNext'].copy()
         totalBPMedsAddedCapped.loc[totalBPMedsAddedCapped >= BaseTreatmentStrategy.MAX_BP_MEDS] = BaseTreatmentStrategy.MAX_BP_MEDS
         #recalibration_df.loc[recalibration_df['totalBPMedsAddedNext'] >= BaseTreatmentStrategy.MAX_BP_MEDS, 'totalBPMedsAddedCapped'] = BaseTreatmentStrategy.MAX_BP_MEDS
         recalibrationVars = {"rolledBackEventType" : [None] * len(recalibration_df),

--- a/microsim/test/test_overall_population_function.py
+++ b/microsim/test/test_overall_population_function.py
@@ -10,6 +10,6 @@ class TestOverallPopulationFunction(unittest.TestCase):
         pop = NHANESDirectSamplePopulation(popSize, 1999)
         for i in range(1, numYears):
             pop.advance_vectorized(years=1)
-
         self.assertEqual(popSize, len(pop._people))
-        self.assertEqual(numYears, len(pop._people.iloc[0]._age))
+        if pop._people.iloc[0]._age[-1] == pop._people.iloc[0]._age[0] + numYears-1: #if person is alive, then check
+           self.assertEqual(numYears, len(pop._people.iloc[0]._age))


### PR DESCRIPTION
We discovered that modelEstimatedRR was always 1 because the estimated risks in the untreated and treated columns were identical due to the estimate_risks method using *last values whereas all the updates were existing on *Next values.

So, the code now moves the *Next values as they become available in two groups, risk factors and treatment, outcomes. All estimated risk methods should now use the *last values which are also the latest ones.

The move_people_df method was broken in two methods, one for risk factors and treatment and one for outcomes.

I have added several comments in advance_vectorized to help me remember how this is  organized, what is happening etc.

I have also reorganized some calculations in advance_vectorized, eg grouped some outcomes, etc, not sure how helpful this is....

I just realized I left the logging.info uncommented...I will comment them out later...

Finally, a lot of the things I did here was optional, so if you think they will not help us much moving forward, I can modify them prior to merging to master...
